### PR TITLE
add LeoFinance and its beta site into white list

### DIFF
--- a/src/config/whitelist.json
+++ b/src/config/whitelist.json
@@ -23,5 +23,7 @@
   "https://nftm.art",
   "https://beta.nftm.art",
   "https://ecency.com",
-  "https://www.cryptobrewmaster.io"
+  "https://www.cryptobrewmaster.io",
+  "https://leofinance.io",
+  "https://beta.leofinance.io"
 ]


### PR DESCRIPTION
### Description

- add LeoFinance and its beta site into redirect url white list

I'm submitting this PR to help LeoFinance project ( @steemleo / https://leofinance.io/@khaleelkazi ) to make it possible to redirect to LeoFinance's sign in page after sign up with HiveOnboard. 

@steemleo could help confirm this is needed by LeoFinance project. 